### PR TITLE
Add optional summary to work experience and add Fedora instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,19 +30,27 @@ To run the LaTeX code from a GitHub repo locally, you can use an editor like Vis
 1. If you haven't already, download and install Visual Studio Code or IntelliJ IDEA
 2. Install the LaTeX Workshop extension for VS Code or the TeXiFy IDEA plugin for IntelliJ IDEA
 3. `git clone` the GitHub repository containing the LaTeX code to your local machine and open it in your text editor or IDE
-4. Download the font with the following curl command and install it
-   ```bash
-   curl "https://mirror.quantum5.ca/CTAN/fonts/tex-gyre.zip" --output ~/Downloads/tex-gyre.zip
-   ```
-6. Install a LaTeX distribution
+4. Install a LaTeX distribution and our fonts
+  * **On Mac**, use maxtex:
+
+    Download the font with the following curl command and install it
+    ```bash
+    curl "https://mirror.quantum5.ca/CTAN/fonts/tex-gyre.zip" --output ~/Downloads/tex-gyre.zip
     ```
+    Then install mactex:
+    ```bash
     brew install --cask mactex-no-gui
     ```
- 7. Use the editor's built-in commands or compile directly in the terminal
+  * **On Fedora Linux**, use texlive:
+    ```bash
+    sudo dnf install texlive-scheme-basic texlive-fontawesome5 texlive-lipsum texlive-relsize texlive-tex-gyre
+    ```
+
+5. Use the editor's built-in commands or compile directly in the terminal
     * Using VS Code with LaTeX Workshop, you can click the "Build LaTeX Project" button
     * Using IntelliJ IDEA with TeXiFy IDEA, you can right-click the `.tex file` and select "Run 'XeLaTeX'"
     * Alternatively, you can compile from the command line using `xelatex -interaction=nonstopmode main.tex`
-7.  After the compilation is complete, you can preview the output PDF file in your editor or your preferred PDF viewer
+6.  After the compilation is complete, you can preview the output PDF file in your editor or your preferred PDF viewer
 
 #### Method 3: Running Locally using a LaTeX job application workflow
 

--- a/career_developer_template/main.tex
+++ b/career_developer_template/main.tex
@@ -42,6 +42,7 @@
     {Company Name} % company name
     {Dec 2020 -- Mar 2022} % beginning and end of employment. If currently employed write " - Present"
     {City, Province} % city, country of employment
+    {Enabled business analysts to track production processes through the development of new consolidated reporting dashboards.} % description of responsibilites (optional)
     {
         \item Designed and implemented a microservices architecture using Java, Spring Boot, and JPA resulting in a 50\% reduction in application response time while increasing system scalability by 75\%.
         \item Developed an event-driven architecture utilizing Kafka to improve data processing efficiency by over 60\%, reducing the average query execution time from minutes to seconds
@@ -55,6 +56,7 @@
     {Company Name} % company name
     {Dec 2017 -- Dec 2020} % beginning and end of employment.
     {City, Province} % city, country of employment
+    {} % description of responsibilites (optional)
     {
         \item Worked with distributed systems building blocks (e.g., Kafka, Redis, Elastic Search) leading to an improvement of data processing speed from minutes down to seconds
         \item Refactored legacy systems to modern microservices architecture utilizing AWS technologies such as Kubernetes S3, SQS, Lambda DynamoDB IAM etc. This improved system performance by up to 40\%
@@ -68,11 +70,11 @@
     {Company Name} % company name
     {Sep 2015 -- Dec 2017} % beginning and end of employment.
     {City, Province} % city, country of employment
+    {} % description of responsibilites (optional)
     {
         \item Designed and developed a scalable backend API using Java, Spring Boot, Hibernate that increased system throughput by 20\% while reducing latency by 15\%
         \item Implemented OLAP databases like Snowflake to support complex analytical queries resulting in an average query response time of less than one second
         \item Developed batch applications using Maven build automation tool which reduced the overall processing time for large data sets from hours to minutes
-        \item Refactored legacy systems with Git version control system resulting in improved code quality and faster development cycles
         \item Utilized AWS technologies such S3, SQS, Lambda, DynamoDB, IAM etc. to design highly available distributed systems that resulted in over 99.9\% uptime
     }
 

--- a/career_developer_template/resume_config.cls
+++ b/career_developer_template/resume_config.cls
@@ -36,11 +36,10 @@
 \RequirePackage{lipsum}
 \RequirePackage{xparse}
 \RequirePackage{relsize}
-\RequirePackage{graphicx}
+\RequirePackage{etoolbox}
+\usepackage{graphicx}
 
 \setmainfont{TeX Gyre Heros} % adjust font style here
-
-% Download the TeX Gyre Heros font here - `curl "https://mirror.quantum5.ca/CTAN/fonts/tex-gyre.zip" --output ~/Downloads/tex-gyre.zip`
 
 % Additional fonts can be found at the following URL: https://www.draketo.de/anderes/latex-fonts.html#org9f59ea3
 
@@ -99,16 +98,22 @@
     \vspace{-15pt}
 }
 
-\newcommand{\WorkExperience}[5]{
+\newcommand{\Summary}[1]{
+  \noindent
+  {#1}
+}
+
+\newcommand{\WorkExperience}[6]{
     \noindent
     \begin{tabular*}{\textwidth}{@{}l @{\extracolsep{\fill}} r}
         \textbf{#1} & \textit{#3} \\
         #2 & #4 \\
     \end{tabular*}
-    
+    \notblank{#5}{ #5}{}
     \begin{itemize}[noitemsep, topsep=0pt, leftmargin=1em]
-        #5
+        #6
     \end{itemize}
+    \vspace{5pt}
 }
 
 \newcommand{\Certification}[3]{


### PR DESCRIPTION
I've added an optional "Summary" for work experience which allows you to describe WHAT you were doing in a job along with what you accomplished as the items.

Sadly, this requires that all the work experience blocks need to get updated. Luckily, since resumes should be ~1 page this isn't usually much work.

I've also added the install instructions for Fedora Linux.