### PR TITLE
Add in work experience (optional) summary

### DIFF
--- a/career_developer_template/main.tex
+++ b/career_developer_template/main.tex
@@ -42,6 +42,7 @@
     {Company Name} % company name
     {Dec 2020 -- Mar 2022} % beginning and end of employment. If currently employed write " - Present"
     {City, Province} % city, country of employment
+    {Enabled business analysts to track production processes through the development of new consolidated reporting dashboards.} % description of responsibilites (optional)
     {
         \item Designed and implemented a microservices architecture using Java, Spring Boot, and JPA resulting in a 50\% reduction in application response time while increasing system scalability by 75\%.
         \item Developed an event-driven architecture utilizing Kafka to improve data processing efficiency by over 60\%, reducing the average query execution time from minutes to seconds
@@ -55,6 +56,7 @@
     {Company Name} % company name
     {Dec 2017 -- Dec 2020} % beginning and end of employment.
     {City, Province} % city, country of employment
+    {} % description of responsibilites (optional)
     {
         \item Worked with distributed systems building blocks (e.g., Kafka, Redis, Elastic Search) leading to an improvement of data processing speed from minutes down to seconds
         \item Refactored legacy systems to modern microservices architecture utilizing AWS technologies such as Kubernetes S3, SQS, Lambda DynamoDB IAM etc. This improved system performance by up to 40\%
@@ -68,11 +70,11 @@
     {Company Name} % company name
     {Sep 2015 -- Dec 2017} % beginning and end of employment.
     {City, Province} % city, country of employment
+    {} % description of responsibilites (optional)
     {
         \item Designed and developed a scalable backend API using Java, Spring Boot, Hibernate that increased system throughput by 20\% while reducing latency by 15\%
         \item Implemented OLAP databases like Snowflake to support complex analytical queries resulting in an average query response time of less than one second
         \item Developed batch applications using Maven build automation tool which reduced the overall processing time for large data sets from hours to minutes
-        \item Refactored legacy systems with Git version control system resulting in improved code quality and faster development cycles
         \item Utilized AWS technologies such S3, SQS, Lambda, DynamoDB, IAM etc. to design highly available distributed systems that resulted in over 99.9\% uptime
     }
 

--- a/career_developer_template/resume_config.cls
+++ b/career_developer_template/resume_config.cls
@@ -36,11 +36,10 @@
 \RequirePackage{lipsum}
 \RequirePackage{xparse}
 \RequirePackage{relsize}
-\RequirePackage{graphicx}
+\RequirePackage{etoolbox}
+\usepackage{graphicx}
 
 \setmainfont{TeX Gyre Heros} % adjust font style here
-
-% Download the TeX Gyre Heros font here - `curl "https://mirror.quantum5.ca/CTAN/fonts/tex-gyre.zip" --output ~/Downloads/tex-gyre.zip`
 
 % Additional fonts can be found at the following URL: https://www.draketo.de/anderes/latex-fonts.html#org9f59ea3
 
@@ -99,16 +98,22 @@
     \vspace{-15pt}
 }
 
-\newcommand{\WorkExperience}[5]{
+\newcommand{\Summary}[1]{
+  \noindent
+  {#1}
+}
+
+\newcommand{\WorkExperience}[6]{
     \noindent
     \begin{tabular*}{\textwidth}{@{}l @{\extracolsep{\fill}} r}
         \textbf{#1} & \textit{#3} \\
         #2 & #4 \\
     \end{tabular*}
-    
+    \notblank{#5}{ #5}{}
     \begin{itemize}[noitemsep, topsep=0pt, leftmargin=1em]
-        #5
+        #6
     \end{itemize}
+    \vspace{5pt}
 }
 
 \newcommand{\Certification}[3]{


### PR DESCRIPTION
I've added an optional "Summary" for work experience which allows you to describe WHAT you were doing in a job along with what you accomplished as the items.

Sadly, this requires that all the work experience blocks need to get updated. Luckily, since resumes should be ~1 page this isn't usually much work.

* Resume scanning tools often look for job responsibilities as in addition to accmplishments in a bullet list.
* Update example resume to include a summary for a single job.
* Update example resume to remove accomplishment item to keep it on a single page.

> Regarding the "description of responsibilities", this section is redundant because your job responsibilities should be conveyed through your job bullets. It's important to mention that recruiters aren't very interested in what your job responsibilities are anyway, they care about business impact and quantitative results.

Yes, I believe this is frequently true for roles that fairly cookie-cutter: Associate Full Stack LAMP Engineer; Oracle Support Desk II; Bitcoin Evangelist. However, there are job titles like "Sales Representative" or "Software Engineering Manager" which may need more information. Indeed even recommends adding such a summary: https://www.indeed.com/career-advice/resumes-cover-letters/write-resume-job-descriptions

But my real goal here is to produce a resume that app.jobscan.co can parse perfectly using your template.... and it appears to usually expect the summary.